### PR TITLE
Add manifest utils

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        platform: [windows-latest, linux-latest, macos-latest]
+        platform: [windows-latest, ubuntu-latest, macos-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
   spec: ["test/**/*.spec.*"],
-  reporter: "spec",
+  reporter: "list",
   require: ["ts-node/register"],
 };

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+**/*
+!/dist/**
+!/lib/**
+!index.js
+!index.d.ts
+!index.d.cts
+!CHANGELOG.md
+!LICENSE
+!MIGRATION_GUIDE.md
+!README.md
+!SECURITY.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2023 Player Nguyen and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -92,11 +92,7 @@ export class VersionManifestUtils {
    * @returns a map that contains all manifest versions
    */
   public getVersionsMap() {
-    const map: Map<string, GameManifestVersion> = new Map();
-    for (const item of this.manifest.versions) {
-      map.set(item.id, item);
-    }
-    return map;
+    return this.searchMap;
   }
 
   /**

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -51,21 +51,98 @@ export async function fetchVersionManifestV2(): Promise<GameVersionManifest> {
   return response.body;
 }
 
+/**
+ * The utility class for solve version manifest problem much easier and faster.
+ */
 export class VersionManifestUtils {
   private manifest: GameVersionManifest;
+  private searchMap: Map<string, GameManifestVersion>;
 
   constructor(manifest: GameVersionManifest) {
     if (manifest === undefined) {
       throw new Error("The manifest parameter cannot be undefined.");
     }
     this.manifest = manifest;
+    this.searchMap = this.getVersionsMap();
   }
+
   /**
-   * Extract the manifest latest release.
+   * Extract the manifest latest release version id.
    *
-   * @returns the latest release
+   * @since 1.0.0
+   * @returns the latest release version id
    */
   public getLatestRelease() {
     return this.manifest.latest.release;
+  }
+
+  /**
+   * Extract the manifest latest snapshot version.
+   *
+   * @since 1.0.0
+   * @returns the latest snapshot version id
+   */
+  public getLatestSnapshot() {
+    return this.manifest.latest.snapshot;
+  }
+
+  /**
+   * Export the versions from manifest as a Map.
+   * @since 1.0.0
+   * @returns a map that contains all manifest versions
+   */
+  public getVersionsMap() {
+    const map: Map<string, GameManifestVersion> = new Map();
+    for (const item of this.manifest.versions) {
+      map.set(item.id, item);
+    }
+    return map;
+  }
+
+  /**
+   * Get the game version property from game version id.
+   * @since 1.0.0
+   * @param id an id of the game version
+   * @returns a GameManifestVersion if the version is exist. Otherwise, undefined will return
+   */
+  public getVersionFromId(id: string) {
+    return this.searchMap.get(id);
+  }
+
+  /**
+   * Iterate over the version list and search for matching items. If the pattern is a string,
+   * using `includes` to compare. If the `pattern` is RegExp, using `match`.
+   *
+   *  @since 1.0.0
+   * @param patterns a string or regexp pattern that match with version id.
+   * @returns a list of items that match to pattern
+   */
+  public searchVersion(pattern: RegExp | string) {
+    if (typeof pattern !== "string" && !(pattern instanceof RegExp)) {
+      throw new Error(
+        "Invalid type of pattern. It must be a string or RegExp."
+      );
+    }
+    const search: GameManifestVersion[] = [];
+    for (const version of this.getVersionsArray()) {
+      if (
+        (typeof pattern === "string" && version.id.includes(pattern)) ||
+        (pattern instanceof RegExp && pattern.test(version.id))
+      ) {
+        search.push(version);
+      }
+    }
+
+    return search;
+  }
+
+  /**
+   * Get all version items as an array by looking the manifest.versions.
+   *
+   * @since 1.0.0
+   * @returns an array contains all versions
+   */
+  public getVersionsArray() {
+    return this.manifest.versions;
   }
 }

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -50,3 +50,22 @@ export async function fetchVersionManifestV2(): Promise<GameVersionManifest> {
   );
   return response.body;
 }
+
+export class VersionManifestUtils {
+  private manifest: GameVersionManifest;
+
+  constructor(manifest: GameVersionManifest) {
+    if (manifest === undefined) {
+      throw new Error("The manifest parameter cannot be undefined.");
+    }
+    this.manifest = manifest;
+  }
+  /**
+   * Extract the manifest latest release.
+   *
+   * @returns the latest release
+   */
+  public getLatestRelease() {
+    return this.manifest.latest.release;
+  }
+}

--- a/test/unit/Manifest.spec.ts
+++ b/test/unit/Manifest.spec.ts
@@ -1,5 +1,10 @@
+import { VersionManifestUtils } from "./../../src/Manifest";
 import { expect } from "chai";
 import { Manifest } from "../../src/Index";
+import {
+  fetchVersionManifestV2,
+  GameVersionManifest,
+} from "../../src/Manifest";
 
 describe("[unit] manifest fetch test", () => {
   it("should response a game version manifest with full property", async () => {
@@ -30,5 +35,27 @@ describe("[unit] manifest fetch test", () => {
     expect(firstGameVersion.sha1).to.be.a("string");
     expect(firstGameVersion.complianceLevel).to.be.a("number");
     // expect(firstGameVersion.time)
+  });
+});
+
+describe("[unit] manifest utils", () => {
+  let manifest: GameVersionManifest;
+
+  before(async () => {
+    manifest = await fetchVersionManifestV2();
+
+    return;
+  });
+
+  it(`should throw with undefined parameter`, () => {
+    expect(() => {
+      new VersionManifestUtils(undefined as unknown as GameVersionManifest);
+    }).to.throw("The manifest parameter cannot be undefined.");
+  });
+
+  it("should return latest release", () => {
+    expect(new VersionManifestUtils(manifest).getLatestRelease()).to.eq(
+      manifest.latest.release
+    );
   });
 });

--- a/test/unit/Manifest.spec.ts
+++ b/test/unit/Manifest.spec.ts
@@ -1,12 +1,33 @@
 import { VersionManifestUtils } from "./../../src/Manifest";
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { Manifest } from "../../src/Index";
 import {
   fetchVersionManifestV2,
   GameVersionManifest,
 } from "../../src/Manifest";
 
-describe("[unit] manifest fetch test", () => {
+/**
+ * Assert if the object that is a game version or not.
+ *
+ * @param gameVersion a game version object to test
+ */
+const assertGameVersion = (gameVersion: any) => {
+  expect(Object.keys(gameVersion)).to.have.members([
+    "id",
+    "type",
+    "url",
+    "time",
+    "releaseTime",
+    "sha1",
+    "complianceLevel",
+  ]);
+
+  expect(gameVersion.id).to.be.a("string");
+  expect(gameVersion.sha1).to.be.a("string");
+  expect(gameVersion.complianceLevel).to.be.a("number");
+};
+
+describe("[unit] manifest fetch test - ", () => {
   it("should response a game version manifest with full property", async () => {
     const manifestData = await Manifest.fetchVersionManifestV2();
     // console.log(manifestData);
@@ -21,24 +42,11 @@ describe("[unit] manifest fetch test", () => {
 
     expect(manifestData.versions).to.be.an("array");
     const firstGameVersion = manifestData.versions[0];
-    expect(Object.keys(firstGameVersion)).to.have.members([
-      "id",
-      "type",
-      "url",
-      "time",
-      "releaseTime",
-      "sha1",
-      "complianceLevel",
-    ]);
-
-    expect(firstGameVersion.id).to.be.a("string");
-    expect(firstGameVersion.sha1).to.be.a("string");
-    expect(firstGameVersion.complianceLevel).to.be.a("number");
-    // expect(firstGameVersion.time)
+    assertGameVersion(firstGameVersion);
   });
 });
 
-describe("[unit] manifest utils", () => {
+describe("[unit] manifest utils - ", () => {
   let manifest: GameVersionManifest;
 
   before(async () => {
@@ -53,9 +61,61 @@ describe("[unit] manifest utils", () => {
     }).to.throw("The manifest parameter cannot be undefined.");
   });
 
-  it("should return latest release", () => {
-    expect(new VersionManifestUtils(manifest).getLatestRelease()).to.eq(
-      manifest.latest.release
+  it("should return latest release and snapshot", () => {
+    const utils = new VersionManifestUtils(manifest);
+    const latestVersion = utils.getLatestRelease();
+    expect(latestVersion).to.eq(manifest.latest.release);
+
+    const snapshotVersion = utils.getLatestSnapshot();
+    expect(snapshotVersion).to.eq(manifest.latest.snapshot);
+  });
+
+  it("should execute get game version with specific game version", () => {
+    const utils = new VersionManifestUtils(manifest);
+
+    const someExistGameVersion = utils.getVersionFromId("1.19.3");
+    expect(someExistGameVersion).to.not.be.undefined;
+    assertGameVersion(someExistGameVersion);
+
+    const someNonExistGameVersion = utils.getVersionFromId(
+      "this-is-a-crazy-version"
     );
+    expect(someNonExistGameVersion).to.be.undefined;
+  });
+
+  it("should search matching version or throw error", () => {
+    const utils = new VersionManifestUtils(manifest);
+
+    // throws an error on undefined or not string | RegExp type
+    expect(() => {
+      utils.searchVersion(12 as unknown as string);
+    }).to.throw("Invalid type of pattern. It must be a string or RegExp.");
+
+    // returns as an array
+    const relativeVersion = utils.searchVersion("1.12");
+    expect(Array.isArray(relativeVersion)).to.be.true;
+    expect(relativeVersion.length).to.be.greaterThan(0);
+
+    // assert any version inside the relative array
+    expect(
+      relativeVersion
+        .map((gameVersion) => assertGameVersion(gameVersion))
+        .every(() => true)
+    ).to.be.true;
+
+    // returns empty array if not found version
+    const mustBeEmptyArray = utils.searchVersion("this-is-so-amazing-version");
+    expect(Array.isArray(mustBeEmptyArray)).to.be.a.string;
+    expect(mustBeEmptyArray.length).to.eq(0);
+
+    // use regex as a search
+    const regexSearch = utils.searchVersion(/1.+/);
+    expect(Array.isArray(regexSearch)).to.be.true;
+    expect(regexSearch.length).to.be.greaterThan(10);
+    expect(
+      relativeVersion
+        .map((gameVersion) => assertGameVersion(gameVersion))
+        .every(() => true)
+    ).to.be.true;
   });
 });


### PR DESCRIPTION
# Describes
Manifest utils is a class that takes input is a `GameVersionManifest` and returns many utilities functions.

# Examples
```javascript
const manifestUtils = new VersionManifestUtils(manifest);

manifestUtils.getLatestRelease() // equivalent to manifest.latest.release

// Get version from the id
manifestUtils.getVersionFromId("1.19.3") //  { id: "1.19.3", ... } 

manifestUtils.searchVersion("1.12"); // Search for all 1.12.* version
manifestUtils.searchVersion(/1.12.+/); // Search as regex 

// You can get the version as an array
manifestUtils .getVersionsArray() //[ { id: a }, { id: b } ]
// or a map
manifestUtils.getVersionsMap() // map [ { ... } ]
```

# Preflight checklist
- [x] All tests passed
- [x] Reviewed code
- [x] Add main function description into pull request