### PR TITLE
Search map was not built on constructor of utils

### DIFF
--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -63,7 +63,10 @@ export class VersionManifestUtils {
       throw new Error("The manifest parameter cannot be undefined.");
     }
     this.manifest = manifest;
-    this.searchMap = this.getVersionsMap();
+    this.searchMap = new Map();
+    for (const version of manifest.versions) {
+      this.searchMap.set(version.id, version);
+    }
   }
 
   /**


### PR DESCRIPTION
Got a 
```
  1) [unit] manifest utils - 
       should execute get game version with specific game version:
     TypeError: Cannot read property 'get' of undefined
      at VersionManifestUtils.getVersionFromId (src/Manifest.ts:52:2)
      at Context.<anonymous> (test/unit/Manifest.spec.ts:76:40)
      at processImmediate (internal/timers.js:464:21)

```